### PR TITLE
added truncate

### DIFF
--- a/aggregate6/aggregate6.py
+++ b/aggregate6/aggregate6.py
@@ -29,7 +29,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from builtins import str as text
-from ipaddress import ip_network
+from ipaddress import ip_network, ip_interface
 
 import aggregate6
 import radix
@@ -111,6 +111,8 @@ Project website: https://github.com/job/aggregate6
 """, formatter_class=argparse.RawTextHelpFormatter)
     p.add_argument('-v', dest='version', action='store_true',
                    help="Display aggregate6 version")
+    p.add_argument('-t', dest='truncate', action='store_true',
+                   help="truncate IP/mask to network/mask")
     afi_group = p.add_mutually_exclusive_group()
     afi_group.add_argument('-4', dest='ipv4_only', action='store_true',
                            default=False,
@@ -139,7 +141,10 @@ def main():
             continue
         for elem in line.strip().split():
             try:
-                prefix_obj = ip_network(text(elem.strip()))
+                if args.truncate:
+                    prefix_obj = ip_interface(text(elem.strip())).network
+                else:
+                    prefix_obj = ip_network(text(elem.strip()))
                 prefix = text(prefix_obj)
             except ValueError:
                 sys.stderr.write("ERROR: '%s' is not a valid IP network, \

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -103,6 +103,14 @@ class TestAggregate(unittest.TestCase):
             agg_main()
         self.assertEqual(sys.stdout.getvalue(), '2001:db8::/32\n')
 
+    def test_13_truncate(self):
+        stub_stdin(self, '2001:db8::1/32 2001:db9::1/32\n10.5.5.5/8\n')
+        stub_stdouts(self)
+        with patch.object(sys, 'argv', ["prog.py", "-t"]):
+            agg_main()
+        self.assertEqual(sys.stdout.getvalue(), '10.0.0.0/8\n2001:db8::/31\n')
+
+
 
 class StringIO(io.StringIO):
     """


### PR DESCRIPTION
'Classic' aggregate tool for IPv4 has useful -t option. This patch implements it for aggregate6.