### PR TITLE
Add tests so they get included in the PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
 include aggregate6.7
 include requirements.txt
+recursive-include tests *.py


### PR DESCRIPTION
Including regression tests in the PyPI makes testing on OpenBSD easier. We use those tests to make sure that ports do not break when we update dependencies.