### PR TITLE
Don't require Python nose and mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6'
     ],
-    setup_requires=["nose", "coverage", "mock"],
+    tests_require=["mock;python_version<'3.3'", "coverage"],
     install_requires=["py-radix==0.10.0"] + (
         ["future", "ipaddress"] if sys.version_info.major == 2 else []
     ),

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -4,7 +4,11 @@ from aggregate6 import aggregate
 from aggregate6.aggregate6 import parse_args
 from aggregate6.aggregate6 import main as agg_main
 
-from mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
 import io
 import sys
 import unittest


### PR DESCRIPTION
  * Nose is dead upstream, but many packages still require it
  * Mock is a 3rd party backport of the (since Python 3.3) standard library `unittest.mock` module

See also:

  * https://fedoraproject.org/wiki/Changes/DeprecateNose
  * https://fedoraproject.org/wiki/Changes/DeprecatePythonMock