### PR TITLE
Add GitHub's Python starter workflow

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -1,0 +1,35 @@
+name: Python package
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          # Stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # For now, treat all errors as warnings using --exit-zero
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=80 --statistics
+      - name: Set $PYTHONPATH
+        run: echo "PYTHONPATH=/home/runner/work/aggregate6/aggregate6" >> $GITHUB_ENV
+      - name: Test with pytest
+        run: pytest


### PR DESCRIPTION
Mainly copied from https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python

Yes, this might not be perfect yet, but it allows to see possible code-related warnings as part of the actions output (and to work on them).