### PR TITLE
Fix multiple issues spotted by flake8

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -28,7 +28,7 @@ jobs:
           # Stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # For now, treat all errors as warnings using --exit-zero
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=80 --statistics
+          flake8 . --count --exit-zero --max-complexity=10 --statistics
       - name: Set $PYTHONPATH
         run: echo "PYTHONPATH=/home/runner/work/aggregate6/aggregate6" >> $GITHUB_ENV
       - name: Test with pytest

--- a/aggregate6/aggregate6.py
+++ b/aggregate6/aggregate6.py
@@ -146,14 +146,14 @@ def main():
 
     args = parse_args(sys.argv[1:])
 
-    if args.version: # pragma: no cover
+    if args.version:  # pragma: no cover
         print("aggregate6 %s" % aggregate6.__version__)
         sys.exit()
 
     p_tree = radix.Radix()
 
     for line in fileinput.input(args.args):
-        if not line.strip(): # pragma: no cover
+        if not line.strip():  # pragma: no cover
             continue
         for elem in line.strip().split():
             try:

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ from os.path import abspath, dirname, join
 
 here = abspath(dirname(__file__))
 
-version = re.search('^__version__\s*=\s*"(.*)"',
+version = re.search(r'^__version__\s*=\s*"(.*)"',
                     open('aggregate6/__init__.py').read(),
                     re.M).group(1)
 
@@ -82,6 +82,6 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     entry_points={'console_scripts':
                   ['aggregate6 = aggregate6.aggregate6:main']},
-    data_files = [('man/man7', ['aggregate6.7'])],
+    data_files=[('man/man7', ['aggregate6.7'])],
     test_suite='nose.collector'
 )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -73,7 +73,8 @@ class TestAggregate(unittest.TestCase):
         stub_stdouts(self)
         with self.assertRaises(Exception) as context:
             aggregate(["this_is_no_prefix", "10.0.0.0/24"])
-        self.assertTrue('ERROR: invalid IP prefix: this_is_no_prefix' in str(context.exception))
+        self.assertTrue('ERROR: invalid IP prefix: this_is_no_prefix' in
+                        str(context.exception))
 
     def test_08__test_args_v4(self):
         self.assertEqual(parse_args(["-4"]).ipv4_only, True)
@@ -93,13 +94,15 @@ class TestAggregate(unittest.TestCase):
         self.assertEqual(sys.stdout.getvalue(), '2001:db8::/32\n')
 
     def test_11_main(self):
-        stub_stdin(self, 'not_a_prefix\n2001:db8::/32\n2001:db8::/128\n10.0.0.0/8\n10.1.2.3/32')
+        stub_stdin(self, 'not_a_prefix\n2001:db8::/32\n2001:db8::/128\n'
+                   '10.0.0.0/8\n10.1.2.3/32')
         stub_stdouts(self)
         with patch.object(sys, 'argv', ["prog.py", "-4"]):
             agg_main()
         self.assertEqual(sys.stdout.getvalue(), '10.0.0.0/8\n')
         self.assertEqual(sys.stderr.getvalue(),
-                         "ERROR: 'not_a_prefix' is not a valid IP network, ignoring.\n")
+                         "ERROR: 'not_a_prefix' is not a valid IP network, "
+                         "ignoring.\n")
 
     def test_12__use_space_in_stdin(self):
         stub_stdin(self, '2001:db8::/32 2001:db8::/128\n10.0.0.0/8\n')
@@ -127,7 +130,9 @@ class TestAggregate(unittest.TestCase):
         stub_stdouts(self)
         with patch.object(sys, 'argv', ["prog.py", "-v"]):
             agg_main()
-        self.assertEqual(sys.stdout.getvalue(), "+ 10.0.0.0/23\n- 10.0.0.0/24\n- 10.0.0.0/32\n- 10.0.1.0/24\n  172.16.0.0/24\n")
+        self.assertEqual(sys.stdout.getvalue(), "+ 10.0.0.0/23\n- "
+                         "10.0.0.0/24\n- 10.0.0.0/32\n- 10.0.1.0/24\n  "
+                         "172.16.0.0/24\n")
 
 
 class StringIO(io.StringIO):
@@ -146,6 +151,7 @@ class StringIO(io.StringIO):
 
 def main():
     unittest.main()
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
- W605 invalid escape sequence '\s'
- E251 unexpected spaces around keyword / parameter equals
- E261 at least two spaces before inline comment
- E501 line too long ({96,88,128} > 80 characters)
- E305 expected 2 blank lines after class or function definition, found 1

For the remaining spotted issues, I'm not sure whether they should be fixed (or how), or if they maybe should be ignored (I don't treat myself as a Python programmer):

```
./aggregate6/aggregate6.py:33:1: E722 do not use bare 'except'
./aggregate6/aggregate6.py:44:15: E741 ambiguous variable name 'l'
./aggregate6/aggregate6.py:58:9: F841 local variable 'err' is assigned to but never used
./aggregate6/aggregate6.py:64:1: C901 'aggregate_tree' is too complex (11)
./aggregate6/aggregate6.py:144:1: C901 'main' is too complex (18)
./aggregate6/aggregate6.py:165:13: F841 local variable 'err' is assigned to but never used
./aggregate6/__init__.py:9:1: F401 '.aggregate6.aggregate' imported but unused
```