### PR TITLE
Test using Python 3.12 (and 3.6 again)

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -7,11 +7,27 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12.0-rc.1"]
+        exclude:
+        - os: ubuntu-latest
+          python-version: 3.6
+        - os: macos-latest
+          python-version: 3.7
+        - os: macos-latest
+          python-version: 3.8
+        - os: macos-latest
+          python-version: 3.9
+        - os: macos-latest
+          python-version: 3.10
+        - os: macos-latest
+          python-version: 3.11
+        - os: macos-latest
+          python-version: 3.12.0-rc.1
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -30,6 +46,6 @@ jobs:
           # For now, treat all errors as warnings using --exit-zero
           flake8 . --count --exit-zero --max-complexity=10 --statistics
       - name: Set $PYTHONPATH
-        run: echo "PYTHONPATH=/home/runner/work/aggregate6/aggregate6" >> $GITHUB_ENV
+        run: echo "PYTHONPATH=$RUNNER_WORKSPACE/aggregate6" >> $GITHUB_ENV
       - name: Test with pytest
         run: pytest

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,8 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11'
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12'
     ],
     tests_require=["mock;python_version<'3.3'", "coverage"],
     install_requires=["py-radix==0.10.0"] + (


### PR DESCRIPTION
Python 3.12 is currently just a release candidate, but some Linux distributions already picked it up, e.g. Fedora. Python 3.6 isn't available for Ubuntu 22.04, so test it on macOS instead.

Fixes #21 and closes #22.