### PR TITLE
Bump Python 3.12 CI test to final release

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12.0-rc.1"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
         - os: ubuntu-latest
           python-version: 3.6
@@ -27,7 +27,7 @@ jobs:
         - os: macos-latest
           python-version: 3.11
         - os: macos-latest
-          python-version: 3.12.0-rc.1
+          python-version: 3.12
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Testing using Python 3.12 was introduced with RC1 (latest at that time), but meanwhile there is a final release – so let's use it.