### PR TITLE
Test using Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -11,19 +11,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-20.04, ubuntu-24.04]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14-dev']
         exclude:
-        - os: macos-latest
+        - os: ubuntu-24.04
+          python-version: 3.6
+        - os: ubuntu-24.04
           python-version: 3.7
-        - os: macos-latest
+        - os: ubuntu-20.04
           python-version: 3.8
-        - os: macos-latest
+        - os: ubuntu-20.04
           python-version: 3.10
-        - os: macos-latest
+        - os: ubuntu-20.04
           python-version: 3.11
-        - os: macos-latest
+        - os: ubuntu-20.04
           python-version: 3.12
+        - os: ubuntu-20.04
+          python-version: 3.13
+        - os: ubuntu-20.04
+          python-version: 3.14-dev
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12'
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13'
     ],
     tests_require=["mock;python_version<'3.3'", "coverage"],
     install_requires=["py-radix==0.10.0"] + (


### PR DESCRIPTION
Python 3.14 is currently just a pre-release, but some Linux distributions already picked it up, e.g. Fedora. Python 3.6 is still in some Linux distributions (RHEL/Rocky Linux 8), so adjust the tests.

Explicitly used ubuntu-24.04, because ubuntu-latest is still 22.04, but will become 24.04 soon (using ubuntu-latest would need some changes soon due differences in available Python versions).