### PR TITLE
Resolve remaining issues spotted by flake8

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -45,8 +45,10 @@ jobs:
         run: |
           # Stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # For now, treat all errors as warnings using --exit-zero
-          flake8 . --count --exit-zero --max-complexity=10 --statistics
+          # For now, ignore F401 ('.aggregate6.aggregate' imported but unused)
+          # as, when removing the import, it at least breaks pytest, accept the
+          # max. complexity of 18 for main() - and just fail otherwise
+          flake8 . --count --ignore=F401 --max-complexity=18 --statistics
       - name: Set $PYTHONPATH
         run: echo "PYTHONPATH=$RUNNER_WORKSPACE/aggregate6" >> $GITHUB_ENV
       - name: Test with pytest

--- a/aggregate6/aggregate6.py
+++ b/aggregate6/aggregate6.py
@@ -89,7 +89,8 @@ def aggregate_tree(l_tree):
         for rnode in tree:
             p = text(ip_network(text(rnode.prefix)).supernet())
             r = tree.search_covered(p)
-            if len(r) == 2 and r[0].prefixlen == r[1].prefixlen == rnode.prefixlen:
+            if len(r) == 2 \
+               and r[0].prefixlen == r[1].prefixlen == rnode.prefixlen:
                 n_tree.add(p)
                 aggregations += 1
             else:


### PR DESCRIPTION
- C901 'main' is too complex (18)
- E501 line too long (83 > 79 characters)
- F401 '.aggregate6.aggregate' imported but unused

As `--exit-zero` is removed, `flake8` might fail hard now, but this hopefully avoids new issues and helps to only improve the current situation.