### PR TITLE
Re-add lost PyPy tests

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-24.04]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14-dev']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14-dev', 'pypy3.9', 'pypy3.10']
         exclude:
         - os: ubuntu-24.04
           python-version: 3.6
@@ -30,6 +30,10 @@ jobs:
           python-version: 3.13
         - os: ubuntu-20.04
           python-version: 3.14-dev
+        - os: ubuntu-20.04
+          python-version: pypy3.9
+        - os: ubuntu-20.04
+          python-version: pypy3.10
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
When Travis was removed with commit 8598395, PyPy tests got lost and weren't added with commit 65741d8 later.