### PR TITLE
Test using Python 3.14 (final) and PyPy 3.11

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -11,29 +11,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-24.04]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14-dev', 'pypy3.9', 'pypy3.10']
+        os: [ubuntu-22.04, ubuntu-24.04]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy3.9', 'pypy3.10', 'pypy3.11']
         exclude:
         - os: ubuntu-24.04
-          python-version: 3.6
-        - os: ubuntu-24.04
           python-version: 3.7
-        - os: ubuntu-20.04
+        - os: ubuntu-22.04
           python-version: 3.8
-        - os: ubuntu-20.04
+        - os: ubuntu-22.04
+          python-version: 3.9
+        - os: ubuntu-22.04
           python-version: 3.10
-        - os: ubuntu-20.04
+        - os: ubuntu-22.04
           python-version: 3.11
-        - os: ubuntu-20.04
+        - os: ubuntu-22.04
           python-version: 3.12
-        - os: ubuntu-20.04
+        - os: ubuntu-22.04
           python-version: 3.13
-        - os: ubuntu-20.04
-          python-version: 3.14-dev
-        - os: ubuntu-20.04
+        - os: ubuntu-22.04
+          python-version: 3.14
+        - os: ubuntu-22.04
           python-version: pypy3.9
-        - os: ubuntu-20.04
+        - os: ubuntu-22.04
           python-version: pypy3.10
+        - os: ubuntu-22.04
+          python-version: pypy3.11
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,8 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13'
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14'
     ],
     tests_require=["mock;python_version<'3.3'", "coverage"],
     install_requires=["py-radix>=0.10.0"] + (


### PR DESCRIPTION
- Remove Python 3.6 tests due to lack of GitHub action support
- Test Python 3.9 only on the current Ubuntu image, not on both
- Switch testing from Python 3.14 pre-release to final
- Add test using PyPy 3.11